### PR TITLE
fix: constant.language.ucase.solidity false-positive

### DIFF
--- a/src/syntaxes/solidity.tmLanguage.json
+++ b/src/syntaxes/solidity.tmLanguage.json
@@ -282,7 +282,7 @@
             "name": "constant.language.currency.solidity"
         },
         "constant-ucase": {
-            "match": "\\b([A-Z0-9_]+)\\b",
+            "match": "\\b((?=\\D)[A-Z_0-9]+)\\b",
             "name": "constant.language.ucase.solidity"
         },
         "number": {


### PR DESCRIPTION
The old regex for `constant.language.ucase.solidity` has false-positives. Specifically, it overrides `constant.numeric.decimal.solidity`

I did this so I can get my green numbers back.

old:
![image](https://user-images.githubusercontent.com/63800471/193517010-c525cdcb-f8da-48ec-99c3-ce279ec9cfb3.png)
new:
![image](https://user-images.githubusercontent.com/63800471/193517035-d1eddac6-2d71-4cf8-b0eb-c4b935725573.png)
