### PR TITLE
Remove hash primitive

### DIFF
--- a/src/syntaxes/solidity.tmLanguage.json
+++ b/src/syntaxes/solidity.tmLanguage.json
@@ -323,7 +323,7 @@
             ]
         },
         "type-primitive": {
-            "match": "\\b(address|string\\d*|bytes\\d*|int\\d*|uint\\d*|bool|hash\\d*|var)\\b",
+            "match": "\\b(address|string\\d*|bytes\\d*|int\\d*|uint\\d*|bool|var)\\b",
             "name": "support.type.primitive.solidity"
         },
         "global": {


### PR DESCRIPTION
I am not sure which solidity version(s) supported a hash primitive, but since `hash` is a not uncommon variable name, even in the [solidity docs](https://docs.soliditylang.org/en/v0.8.20/cheatsheet.html#mathematical-and-cryptographic-functions), it may make sense to remove this from the primitive list for the latest solidity versions.